### PR TITLE
Fix-fix_attribution

### DIFF
--- a/wranglertools/fdnDCIC.py
+++ b/wranglertools/fdnDCIC.py
@@ -45,7 +45,7 @@ class FDN_Connection(object):
             self.user = res['@id']
             self.email = res['email']
             try:
-                self.lab = res['lab']
+                self.lab = res['submits_for']
                 lab_url = self.server + self.lab + '?frame=embedded'
                 r_lab = requests.get(lab_url, auth=self.auth)
                 res_lab = r_lab.json()

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -440,7 +440,7 @@ def excel_reader(datafile, sheet, update, connection, patchall,
         # Get existing data if available
         existing_data = get_existing(post_json, connection)
         # if no existing data (new item), add missing award/lab information from submitter
-        if not existing_data.get("uuid"):
+        if not existing_data.get("award"):
             post_json = fix_attribution(sheet, post_json, connection)
         # Filter loadxl fields
         post_json, patch_loadxl_item = filter_loadxl_fields(post_json, sheet)

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -426,7 +426,6 @@ def excel_reader(datafile, sheet, update, connection, patchall,
         total += 1
         post_json = dict(zip(keys, values))
         post_json = build_patch_json(post_json, fields2types)
-        post_json = fix_attribution(sheet, post_json, connection)
         # add attchments here
         if post_json.get("attachment"):
             attach = attachment(post_json["attachment"])
@@ -440,6 +439,9 @@ def excel_reader(datafile, sheet, update, connection, patchall,
             file_to_upload = True
         # Get existing data if available
         existing_data = get_existing(post_json, connection)
+        # if no existing data (new item), add missing award/lab information from submitter
+        if not existing_data.get("uuid"):
+            post_json = fix_attribution(sheet, post_json, connection)
         # Filter loadxl fields
         post_json, patch_loadxl_item = filter_loadxl_fields(post_json, sheet)
         # Filter experiment set related fields from experiment


### PR DESCRIPTION
I found a bug where patching new information on existing items changed the original attribution of the item (lab and award) to the patching person (status changes by admin changed the attribution to admin which is not wanted). It is still possible to patch the lab and award to change the attribution if needed.