### PR TITLE
Changes in reporting of upload md5 error

### DIFF
--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -708,6 +708,8 @@ def post_item(file_to_upload, post_json, filename_to_post, connection, sheet):
         post_json['md5sum'] = md5(filename_to_post)
     e = submit_utils.new_FDN(connection, sheet, post_json)
     if file_to_upload:
+        if e.get('status') == 'error':
+            return e
         # upload the file
         upload_file(e, filename_to_post)
         if ftp_download:
@@ -975,6 +977,7 @@ def excel_reader(datafile, sheet, update, connection, patchall, aliases_by_type,
                 # error += 1
                 if e.get('detail').startswith("Keys conflict: [('alias', 'md5:"):
                     print("Upload failure - md5 of file matches another item in database.")
+                    print(error_rep)
                 else:
                     print(error_rep)
             # if error is a weird one

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -834,7 +834,7 @@ def check_file_pairing(fastq_row):
             err = "alias missing - can't check file pairing"
             errors = _add_e_to_edict('unaliased', err, errors)
             continue
-        paired_end = row[pair_idx]
+        paired_end = row[pair_idx] if pair_idx else None
         saw_pair = False
         for i, fld in enumerate(row):
             if fld.strip() == 'paired with':


### PR DESCRIPTION
- Edited import_data.post_item and import_data.patch_item so that if the response.json returns an error, the error is returned before the function tries the next steps
- If patch or post error is due to md5 conflict, returns a more human readable error message
- Edited a line in import_data.check_file_pairing so that single-end fastq rows with no pairing information no longer cause an error