### PR TITLE
Add produced_from to list of fields ignored by validator

### DIFF
--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -455,8 +455,9 @@ def pre_validate_json(post_json, fields2types, aliases_by_type, connection):
         # ignore empty fields
         if not field_data:
             continue
-        # ignore aliases field as this was validated before
-        if field == 'aliases':
+        # ignore certain fields - aliases validated before
+        # source_experiments and produced_from hold strings of aliases by design
+        if field in ['aliases', 'produced_from', 'source_experiments']:
             continue
 
         field_type = get_f_type(field, fields2types)


### PR DESCRIPTION
Quick fix so strings in produced_from field don't cause a validation error as they can look like aliases or uuids or accessions.