### PR TITLE
Tweak remote 2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ class MockedConnection(object):
         self.award = 'test_award'
         return
 
-    def prompt_for_lab_award(self):
+    def prompt_for_lab_award(self, lab=None, award=None):
         self.lab = 'test_lab'
         return
 
@@ -471,6 +471,34 @@ def returned_lab_w_two_awards():
 
 
 @pytest.fixture
+def returned_lab_w_two_awards_objframe():
+    data = {
+        'awards': ['/awards/1U54DK107977-01/', '/awards/1U01ES017166-01/'],
+        'title': 'Bing Ren, UCSD', 'link_id': '~labs~bing-ren-lab~', 'institute_label': 'UCSD', '@id': '/labs/bing-ren-lab/',
+        'status': 'current', 'uuid': '795847de-20b6-4f8c-ba8d-185215469cbf', 'display_title': 'Bing Ren, UCSD',
+        'name': 'bing-ren-lab', '@type': ['Lab', 'Item']
+    }
+    return MockedResponse(data, 200)
+
+
+@pytest.fixture
+def returned_award_objframe():
+    data = {
+        "uuid": "1dbecc95-ec91-4081-a862-c79d18a8d0bd",
+        "@id": "/awards/1U01ES017166-01/",
+        "title": "THE SAN DIEGO EPIGENOME CENTER",
+        "@type": ["Award", "Item"],
+        "project": "External",
+        "name": "1U01ES017166-01",
+        "link_id": "~awards~1U01ES017166-01~",
+        "viewing_group": "Not 4DN",
+        "pi": "/users/e3159ffc-a5a9-43a1-8cfa-90b776c39788/",
+        "status": "current"
+    }
+    return MockedResponse(data, 200)
+
+
+@pytest.fixture
 def returned_otherlab_w_two_awards():
     data = {
         'awards': [
@@ -496,52 +524,52 @@ def returned_otherlab_w_two_awards():
     return MockedResponse(data, 200)
 
 
-@pytest.fixture
-def returned_lab_w_awards_raw():
-    data = {
-        "pi": "e3159ffc-a5a9-43a1-8cfa-90b776c39788",
-        "title": "Bing Ren, UCSD",
-        "institute_name": "University of California, San Diego",
-        "name": "bing-ren-lab",
-        "date_created": "2017-04-08T13:01:38.072587+00:00",
-        "uuid": "795847de-20b6-4f8c-ba8d-185215469cbf",
-        "submitted_by": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
-        "status": "current",
-        "institute_label": "UCSD",
-        "schema_version": "1",
-        "last_modified": {
-            "modified_by": "986b362f-4eb6-4a9c-8173-3ab267227777",
-            "date_modified": "2019-03-13T20:26:18.004090+00:00"
-        },
-        "awards": [
-            "4871e338-b07d-4665-a00a-357648e5bad6",
-            "1dbecc95-ec91-4081-a862-c79d18a8d0bd",
-            "c55dd1f0-433b-4714-bfce-8b3ae09f071c",
-            "d61f0a46-7e58-477f-b23d-198854b11276"
-        ]
-    }
-    return MockedResponse(data, 200)
+# @pytest.fixture
+# def returned_lab_w_awards_raw():
+#     data = {
+#         "pi": "e3159ffc-a5a9-43a1-8cfa-90b776c39788",
+#         "title": "Bing Ren, UCSD",
+#         "institute_name": "University of California, San Diego",
+#         "name": "bing-ren-lab",
+#         "date_created": "2017-04-08T13:01:38.072587+00:00",
+#         "uuid": "795847de-20b6-4f8c-ba8d-185215469cbf",
+#         "submitted_by": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
+#         "status": "current",
+#         "institute_label": "UCSD",
+#         "schema_version": "1",
+#         "last_modified": {
+#             "modified_by": "986b362f-4eb6-4a9c-8173-3ab267227777",
+#             "date_modified": "2019-03-13T20:26:18.004090+00:00"
+#         },
+#         "awards": [
+#             "4871e338-b07d-4665-a00a-357648e5bad6",
+#             "1dbecc95-ec91-4081-a862-c79d18a8d0bd",
+#             "c55dd1f0-433b-4714-bfce-8b3ae09f071c",
+#             "d61f0a46-7e58-477f-b23d-198854b11276"
+#         ]
+#     }
+#     return MockedResponse(data, 200)
 
 
-@pytest.fixture
-def returned_award_raw():
-    data = {
-        "project": "4DN",
-        "title": "THE ORGANIZATIONAL HUB AND WEB PORTAL FOR THE 4D NUCLEOME NETWORK",
-        "name": "1U01CA200147-01",
-        "uuid": "c55dd1f0-433b-4714-bfce-8b3ae09f071c",
-        "url": "https://projectreporter.nih.gov/project_description.cfm?projectnumber=1U01CA200147-01",
-        "submitted_by": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
-        "status": "current",
-        "viewing_group": "4DN",
-        "description": "Truncated description ...",
-        "date_created": "2017-04-08T13:01:36.766611+00:00",
-        "last_modified": {
-            "modified_by": "986b362f-4eb6-4a9c-8173-3ab267227777",
-            "date_modified": "2018-12-17T17:38:19.212770+00:00"
-        },
-        "schema_version": "1",
-        "pi": "5549e16d-fa63-477c-a1ed-6189cecc1304",
-        "end_date": "2020-08-31"
-    }
-    return MockedResponse(data, 200)
+# @pytest.fixture
+# def returned_award_raw():
+#     data = {
+#         "project": "4DN",
+#         "title": "THE ORGANIZATIONAL HUB AND WEB PORTAL FOR THE 4D NUCLEOME NETWORK",
+#         "name": "1U01CA200147-01",
+#         "uuid": "c55dd1f0-433b-4714-bfce-8b3ae09f071c",
+#         "url": "https://projectreporter.nih.gov/project_description.cfm?projectnumber=1U01CA200147-01",
+#         "submitted_by": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
+#         "status": "current",
+#         "viewing_group": "4DN",
+#         "description": "Truncated description ...",
+#         "date_created": "2017-04-08T13:01:36.766611+00:00",
+#         "last_modified": {
+#             "modified_by": "986b362f-4eb6-4a9c-8173-3ab267227777",
+#             "date_modified": "2018-12-17T17:38:19.212770+00:00"
+#         },
+#         "schema_version": "1",
+#         "pi": "5549e16d-fa63-477c-a1ed-6189cecc1304",
+#         "end_date": "2020-08-31"
+#     }
+#     return MockedResponse(data, 200)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -494,3 +494,54 @@ def returned_otherlab_w_two_awards():
         'status': 'current', 'name': 'ben-ring-lab', '@type': ['Lab', 'Item']
     }
     return MockedResponse(data, 200)
+
+
+@pytest.fixture
+def returned_lab_w_awards_raw():
+    data = {
+        "pi": "e3159ffc-a5a9-43a1-8cfa-90b776c39788",
+        "title": "Bing Ren, UCSD",
+        "institute_name": "University of California, San Diego",
+        "name": "bing-ren-lab",
+        "date_created": "2017-04-08T13:01:38.072587+00:00",
+        "uuid": "795847de-20b6-4f8c-ba8d-185215469cbf",
+        "submitted_by": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
+        "status": "current",
+        "institute_label": "UCSD",
+        "schema_version": "1",
+        "last_modified": {
+            "modified_by": "986b362f-4eb6-4a9c-8173-3ab267227777",
+            "date_modified": "2019-03-13T20:26:18.004090+00:00"
+        },
+        "awards": [
+            "4871e338-b07d-4665-a00a-357648e5bad6",
+            "1dbecc95-ec91-4081-a862-c79d18a8d0bd",
+            "c55dd1f0-433b-4714-bfce-8b3ae09f071c",
+            "d61f0a46-7e58-477f-b23d-198854b11276"
+        ]
+    }
+    return MockedResponse(data, 200)
+
+
+@pytest.fixture
+def returned_award_raw():
+    data = {
+        "project": "4DN",
+        "title": "THE ORGANIZATIONAL HUB AND WEB PORTAL FOR THE 4D NUCLEOME NETWORK",
+        "name": "1U01CA200147-01",
+        "uuid": "c55dd1f0-433b-4714-bfce-8b3ae09f071c",
+        "url": "https://projectreporter.nih.gov/project_description.cfm?projectnumber=1U01CA200147-01",
+        "submitted_by": "986b362f-4eb6-4a9c-8173-3ab267307e3a",
+        "status": "current",
+        "viewing_group": "4DN",
+        "description": "Truncated description ...",
+        "date_created": "2017-04-08T13:01:36.766611+00:00",
+        "last_modified": {
+            "modified_by": "986b362f-4eb6-4a9c-8173-3ab267227777",
+            "date_modified": "2018-12-17T17:38:19.212770+00:00"
+        },
+        "schema_version": "1",
+        "pi": "5549e16d-fa63-477c-a1ed-6189cecc1304",
+        "end_date": "2020-08-31"
+    }
+    return MockedResponse(data, 200)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ class MockedConnection(object):
         self.labs = ['test_lab']
         self.email = 'test@test.test'
 
-    def set_award(self):
+    def set_award(self, lab, dontPrompt=False):
         self.award = 'test_award'
         return
 

--- a/tests/test_get_field_info.py
+++ b/tests/test_get_field_info.py
@@ -132,7 +132,7 @@ def test_connection_prompt_for_lab_award_multi_lab_bad_choice(
         assert connection.award == defaultaward
         # monkeypatch the "input" function, so that it returns "2".
         # This simulates the user entering "2" in the terminal:
-        monkeypatch.setattr('builtins.input', lambda x: "3")
+        monkeypatch.setitem(__builtins__, 'input', lambda x: "3")
         connection.prompt_for_lab_award()
         assert connection.lab == defaultlab
         assert connection.award == defaultaward

--- a/tests/test_get_field_info.py
+++ b/tests/test_get_field_info.py
@@ -148,7 +148,6 @@ def test_connection_prompt_for_lab_award_multi_award(
         to a lab the first is set as the defaul on init
     '''
     defaultlab = '/labs/bing-ren-lab/'
-    defaultaward = '/awards/1U54DK107977-01/'
     chosenaward = '/awards/1U01ES017166-01/'
     with mocker.patch('dcicutils.ff_utils.get_metadata',
                       side_effect=[returned_user_me_submit_for_one_lab.json(),
@@ -169,7 +168,6 @@ def test_connection_prompt_for_lab_award_multi_lab_award(
     mocker, monkeypatch, mkey, returned_user_me_submit_for_two_labs,
         returned_lab_w_two_awards, returned_otherlab_w_two_awards):
     defaultlab = '/labs/bing-ren-lab/'
-    defaultaward = '/awards/1U54DK107977-01/'
     chosenlab = '/labs/ben-ring-lab/'
     chosenaward = '/awards/7777777/'
     with mocker.patch('dcicutils.ff_utils.get_metadata',

--- a/tests/test_get_field_info.py
+++ b/tests/test_get_field_info.py
@@ -185,21 +185,6 @@ def test_connection_prompt_for_lab_award_multi_lab_award(
         assert connection.award == chosenaward
 
 
-def test_connection_no_prompt_if_no_labs(mocker, mkey, returned_user_me_submit_for_one_lab,
-                                         returned_lab_w_one_award):
-    '''using as remote user who has only one lab submits_for that has one award
-       in this case checking to make sure that lab and award are still present on connection
-    '''
-    with mocker.patch('dcicutils.ff_utils.get_metadata',
-                      side_effect=[returned_user_me_submit_for_one_lab.json(),
-                                   returned_lab_w_one_award.json()]):
-        connection = gfi.FDN_Connection(mkey)
-        connection.labs = None
-        connection.prompt_for_lab_award()
-        assert connection.labs is None
-        assert connection.award is None
-
-
 def test_set_award_no_lab(mocker, mkey, returned_user_me_submit_for_one_lab,
                           returned_lab_w_one_award):
     with mocker.patch('dcicutils.ff_utils.get_metadata',

--- a/tests/test_get_field_info.py
+++ b/tests/test_get_field_info.py
@@ -123,8 +123,6 @@ def test_connection_prompt_for_lab_award_multi_lab_bad_choice(
         returned_lab_w_one_award, returned_otherlab_w_one_award, capsys):
     defaultlab = '/labs/bing-ren-lab/'
     defaultaward = '/awards/1U54DK107977-01/'
-    chosenlab = '/labs/ben-ring-lab/'
-    chosenaward = '/awards/1U01ES017166-01/'
     with mocker.patch('dcicutils.ff_utils.get_metadata',
                       side_effect=[returned_user_me_submit_for_two_labs.json(),
                                    returned_lab_w_one_award.json(),

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -697,7 +697,9 @@ def test_cabin_cross_check_remote_w_lab_award_options(mocker, connection_mock, c
                               returned_lab_w_awards_raw.json(),
                               returned_award_raw.json()]):
             connection_mock.labs = ['test_lab', 'other_lab']
-            imp.cabin_cross_check(connection_mock, False, False, 'blah', True, '795847de-20b6-4f8c-ba8d-185215469cbf', 'c55dd1f0-433b-4714-bfce-8b3ae09f071c')
+            imp.cabin_cross_check(connection_mock, False, False, 'blah', True,
+                                  '795847de-20b6-4f8c-ba8d-185215469cbf',
+                                  'c55dd1f0-433b-4714-bfce-8b3ae09f071c')
             out = capsys.readouterr()[0]
             message = '''
 Running on:       https://data.4dnucleome.org/
@@ -720,7 +722,8 @@ def test_cabin_cross_check_remote_w_award_and_no_lab_options(mocker, connection_
                           side_effect=[pytest.raises(TypeError), returned_award_raw.json()]):
             with pytest.raises(SystemExit):
                 connection_mock.labs = ['test_lab', 'other_lab']
-                imp.cabin_cross_check(connection_mock, False, False, 'blah', True, None, 'c55dd1f0-433b-4714-bfce-8b3ae09f071c')
+                imp.cabin_cross_check(connection_mock, False, False, 'blah', True,
+                                      None, 'c55dd1f0-433b-4714-bfce-8b3ae09f071c')
             out = capsys.readouterr()[0]
             message = '''
 Running on:       https://data.4dnucleome.org/
@@ -737,7 +740,8 @@ def test_cabin_cross_check_remote_w_labopt_and_no_award(mocker, connection_mock,
         with mocker.patch('dcicutils.ff_utils.get_metadata',
                           return_value=returned_lab_w_awards_raw.json()):
             connection_mock.labs = ['test_lab', 'other_lab']
-            imp.cabin_cross_check(connection_mock, False, False, 'blah', True, '795847de-20b6-4f8c-ba8d-185215469cbf', None)
+            imp.cabin_cross_check(connection_mock, False, False, 'blah', True,
+                                  '795847de-20b6-4f8c-ba8d-185215469cbf', None)
             out = capsys.readouterr()[0]
             message = '''
 Running on:       https://data.4dnucleome.org/

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -655,7 +655,7 @@ def test_loadxl_cycle(capsys, mocker, connection_mock):
 
 @pytest.mark.file_operation
 def test_cabin_cross_check_dryrun(connection_mock, capsys):
-    imp.cabin_cross_check(connection_mock, False, False, './tests/data_files/Exp_Set_insert.xls', False)
+    imp.cabin_cross_check(connection_mock, False, False, './tests/data_files/Exp_Set_insert.xls', False, None, None)
     out = capsys.readouterr()[0]
     message = '''
 Running on:       https://data.4dnucleome.org/
@@ -673,7 +673,7 @@ The validation will only check for schema rules, but not for object relations
 
 def test_cabin_cross_check_remote_w_single_lab_award(mocker, connection_mock, capsys):
     with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
-        imp.cabin_cross_check(connection_mock, False, False, 'blah', True)
+        imp.cabin_cross_check(connection_mock, False, False, 'blah', True, None, None)
         out = capsys.readouterr()[0]
         message = '''
 Running on:       https://data.4dnucleome.org/
@@ -687,7 +687,94 @@ The validation will only check for schema rules, but not for object relations
 ##############   DRY-RUN MODE   ################
 '''
         assert out.strip() == message.strip()
-    pass
+
+
+def test_cabin_cross_check_remote_w_lab_award_options(mocker, connection_mock, capsys,
+                                                      returned_lab_w_awards_raw, returned_award_raw):
+    with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
+        with mocker.patch('dcicutils.ff_utils.get_metadata',
+                          side_effect=[
+                              returned_lab_w_awards_raw.json(),
+                              returned_award_raw.json()]):
+            connection_mock.labs = ['test_lab', 'other_lab']
+            imp.cabin_cross_check(connection_mock, False, False, 'blah', True, '795847de-20b6-4f8c-ba8d-185215469cbf', 'c55dd1f0-433b-4714-bfce-8b3ae09f071c')
+            out = capsys.readouterr()[0]
+            message = '''
+Running on:       https://data.4dnucleome.org/
+Submitting User:  test@test.test
+Submitting Lab:   795847de-20b6-4f8c-ba8d-185215469cbf
+Submitting Award: c55dd1f0-433b-4714-bfce-8b3ae09f071c
+
+##############   DRY-RUN MODE   ################
+Since there are no '--update' and/or '--patchall' arguments, you are running the DRY-RUN validation
+The validation will only check for schema rules, but not for object relations
+##############   DRY-RUN MODE   ################
+'''
+            assert out.strip() == message.strip()
+
+
+def test_cabin_cross_check_remote_w_award_and_no_lab_options(mocker, connection_mock, capsys,
+                                                             returned_lab_w_awards_raw, returned_award_raw):
+    with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
+        with mocker.patch('dcicutils.ff_utils.get_metadata',
+                          side_effect=[pytest.raises(TypeError), returned_award_raw.json()]):
+            with pytest.raises(SystemExit):
+                connection_mock.labs = ['test_lab', 'other_lab']
+                imp.cabin_cross_check(connection_mock, False, False, 'blah', True, None, 'c55dd1f0-433b-4714-bfce-8b3ae09f071c')
+            out = capsys.readouterr()[0]
+            message = '''
+Running on:       https://data.4dnucleome.org/
+Submitting Lab NOT FOUND: None
+Submitting award:   c55dd1f0-433b-4714-bfce-8b3ae09f071c
+ERROR: --award option used but lab not found (check --lab option) - exiting!
+'''
+            assert out.strip() == message.strip()
+
+
+def test_cabin_cross_check_remote_w_labopt_and_no_award(mocker, connection_mock, capsys,
+                                                        returned_lab_w_awards_raw):
+    with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
+        with mocker.patch('dcicutils.ff_utils.get_metadata',
+                          return_value=returned_lab_w_awards_raw.json()):
+            connection_mock.labs = ['test_lab', 'other_lab']
+            imp.cabin_cross_check(connection_mock, False, False, 'blah', True, '795847de-20b6-4f8c-ba8d-185215469cbf', None)
+            out = capsys.readouterr()[0]
+            message = '''
+Running on:       https://data.4dnucleome.org/
+Submitting User:  test@test.test
+Submitting Lab:   795847de-20b6-4f8c-ba8d-185215469cbf
+Submitting Award: test_award
+
+##############   DRY-RUN MODE   ################
+Since there are no '--update' and/or '--patchall' arguments, you are running the DRY-RUN validation
+The validation will only check for schema rules, but not for object relations
+##############   DRY-RUN MODE   ################
+'''
+            assert out.strip() == message.strip()
+
+
+def test_cabin_cross_check_remote_w_unknown_lab_and_award(mocker, connection_mock, capsys,
+                                                          returned_lab_w_awards_raw):
+    with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
+        with mocker.patch('dcicutils.ff_utils.get_metadata', side_effect=pytest.raises(TypeError)):
+            connection_mock.labs = ['test_lab', 'other_lab']
+            connection_mock.set_award = lambda x: None
+            imp.cabin_cross_check(connection_mock, False, False, 'blah', True, 'unknown_lab', 'unknown_award')
+            out = capsys.readouterr()[0]
+            message = '''
+Running on:       https://data.4dnucleome.org/
+Submitting Lab NOT FOUND: unknown_lab
+Submitting award NOT FOUND: unknown_award
+Submitting User:  test@test.test
+WARNING: Submitting Lab and Award Unspecified
+Lab and Award info must be included for all items or submission will fail
+
+##############   DRY-RUN MODE   ################
+Since there are no '--update' and/or '--patchall' arguments, you are running the DRY-RUN validation
+The validation will only check for schema rules, but not for object relations
+##############   DRY-RUN MODE   ################
+'''
+            assert out.strip() == message.strip()
 # Disabled - public account is not compatible with the connection object at the moment
 # # TODO: use mastertest tests for this purpose
 # def test_get_collections(connection_public):

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -779,6 +779,35 @@ The validation will only check for schema rules, but not for object relations
 ##############   DRY-RUN MODE   ################
 '''
             assert out.strip() == message.strip()
+
+
+def test_cabin_cross_check_remote_w_award_not_for_lab_options(mocker, connection_mock, capsys,
+                                                              returned_lab_w_awards_raw, returned_award_raw):
+    award_data = returned_award_raw.json()
+    award_data['uuid'] = 'non-lab-award-uuid'
+    with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
+        with mocker.patch('dcicutils.ff_utils.get_metadata',
+                          side_effect=[
+                              returned_lab_w_awards_raw.json(),
+                              returned_award_raw.json()]):
+            connection_mock.labs = ['test_lab', 'other_lab']
+            imp.cabin_cross_check(connection_mock, False, False, 'blah', True,
+                                  '795847de-20b6-4f8c-ba8d-185215469cbf',
+                                  'non-lab-award-uuid')
+            out = capsys.readouterr()[0]
+            message = '''
+Running on:       https://data.4dnucleome.org/
+Award non-lab-award-uuid not associated with lab 795847de-20b6-4f8c-ba8d-185215469cbf
+Submitting User:  test@test.test
+Submitting Lab:   795847de-20b6-4f8c-ba8d-185215469cbf
+Submitting Award: None
+
+##############   DRY-RUN MODE   ################
+Since there are no '--update' and/or '--patchall' arguments, you are running the DRY-RUN validation
+The validation will only check for schema rules, but not for object relations
+##############   DRY-RUN MODE   ################
+'''
+            assert out.strip() == message.strip()
 # Disabled - public account is not compatible with the connection object at the moment
 # # TODO: use mastertest tests for this purpose
 # def test_get_collections(connection_public):

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -672,7 +672,7 @@ The validation will only check for schema rules, but not for object relations
 
 
 def test_cabin_cross_check_remote_w_single_lab_award(mocker, connection_mock, capsys):
-    with mocker.patch('imp.os.path.isfile', return_value=True):
+    with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
         imp.cabin_cross_check(connection_mock, False, False, 'blah', True)
         out = capsys.readouterr()[0]
         message = '''

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -653,6 +653,20 @@ def test_loadxl_cycle(capsys, mocker, connection_mock):
         assert message == out.strip()
 
 
+def test_verify_and_return_item_good_item(mocker, connection_mock, returned_award_objframe):
+    with mocker.patch('dcicutils.ff_utils.get_metadata',
+                      return_value=returned_award_objframe.json()):
+        res = imp._verify_and_return_item('/awards/1U01ES017166-01/', connection_mock)
+        assert res == returned_award_objframe.json()
+
+
+def test_verify_and_return_item_bad_item(mocker, connection_mock):
+    with mocker.patch('dcicutils.ff_utils.get_metadata',
+                      return_value=None):
+        res = imp._verify_and_return_item('blah', connection_mock)
+        assert res is None
+
+
 @pytest.mark.file_operation
 def test_cabin_cross_check_dryrun(mocker, connection_mock, capsys):
     with mocker.patch('wranglertools.import_data._verify_and_return_item',

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -783,6 +783,35 @@ The validation will only check for schema rules, but not for object relations
             assert out.strip() == message.strip()
 
 
+def test_cabin_cross_check_remote_w_multilabs_no_options(mocker, connection_mock, capsys):
+    with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
+        with mocker.patch('wranglertools.import_data._verify_and_return_item',
+                          side_effect=[None, None]):
+            connection_mock.labs = ['/labs/bing-ren-lab/', '/labs/test-lab/']
+            connection_mock.award = None
+            connection_mock.set_award = lambda x, y: None
+            imp.cabin_cross_check(connection_mock, False, False, 'blah', True,
+                                  None, None)
+            out = capsys.readouterr()[0]
+            print(out)
+            message = '''
+Running on:       https://data.4dnucleome.org/
+Submitting Lab NOT FOUND: None
+Submitting award NOT FOUND: None
+Submitting User:  test@test.test
+WARNING: Submitting Lab and Award Unspecified
+Lab and Award info must be included for all items or submission will fail
+Submitting Lab:   None
+Submitting Award: None
+
+##############   DRY-RUN MODE   ################
+Since there are no '--update' and/or '--patchall' arguments, you are running the DRY-RUN validation
+The validation will only check for schema rules, but not for object relations
+##############   DRY-RUN MODE   ################
+'''
+            assert out.strip() == message.strip()
+
+
 def test_cabin_cross_check_remote_w_labopt_and_lab_has_single_award(mocker, connection_mock, capsys):
     with mocker.patch('wranglertools.import_data.os.path.isfile', return_value=True):
         with mocker.patch('wranglertools.import_data._verify_and_return_item',
@@ -811,7 +840,6 @@ def test_cabin_cross_check_remote_w_unknown_lab_and_award(mocker, connection_moc
         with mocker.patch('wranglertools.import_data._verify_and_return_item',
                           side_effect=[None, None]):
             connection_mock.labs = ['test_lab', 'other_lab']
-            # connection_mock.set_award = lambda x: None
             imp.cabin_cross_check(connection_mock, False, False, 'blah', True, 'unknown_lab', 'unknown_award')
             out = capsys.readouterr()[0]
             message = '''

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -671,6 +671,23 @@ The validation will only check for schema rules, but not for object relations
     assert out.strip() == message.strip()
 
 
+def test_cabin_cross_check_remote_w_single_lab_award(mocker, connection_mock, capsys):
+    with mocker.patch('imp.os.path.isfile', return_value=True):
+        imp.cabin_cross_check(connection_mock, False, False, 'blah', True)
+        out = capsys.readouterr()[0]
+        message = '''
+Running on:       https://data.4dnucleome.org/
+Submitting User:  test@test.test
+Submitting Lab:   test_lab
+Submitting Award: test_award
+
+##############   DRY-RUN MODE   ################
+Since there are no '--update' and/or '--patchall' arguments, you are running the DRY-RUN validation
+The validation will only check for schema rules, but not for object relations
+##############   DRY-RUN MODE   ################
+'''
+        assert out.strip() == message.strip()
+    pass
 # Disabled - public account is not compatible with the connection object at the moment
 # # TODO: use mastertest tests for this purpose
 # def test_get_collections(connection_public):

--- a/wranglertools/get_field_info.py
+++ b/wranglertools/get_field_info.py
@@ -177,12 +177,12 @@ class FDN_Connection(object):
                 self.award = awards[int(awd_resp) - 1]['@id']
         return
 
-    def prompt_for_lab_award(self):
+    def prompt_for_lab_award(self, lab=None, award=None):
         '''Check to see if user submits_for multiple labs or the lab
             has multiple awards and if so prompts for the one to set
             for the connection
         '''
-        if self.labs is not None:
+        if not lab and self.labs is not None:
             if len(self.labs) > 1:
                 lchoices = []
                 print("Submitting for multiple labs:")
@@ -196,9 +196,11 @@ class FDN_Connection(object):
                     return
                 else:
                     self.lab = self.labs[int(lab_resp) - 1]
-            self.set_award(self.lab, False)
+            if not award:
+                self.set_award(self.lab, False)
         else:
-            self.set_award(None)
+            if not award:
+                self.set_award(None)
 
 
 @attr.s

--- a/wranglertools/get_field_info.py
+++ b/wranglertools/get_field_info.py
@@ -138,50 +138,51 @@ class FDN_Connection(object):
             # take the first one as default value for the connection - reset in
             # import_data if needed by calling set_lab_award
             self.lab = self.labs[0]
-            self.set_award(self.lab)  # set as default first
+            self.set_award(self.lab, dontPrompt=True)  # set as default first
         else:
             self.labs = None
             self.lab = None
             self.award = None
 
-    def set_award(self, lab, dontPrompt=True):
+    def set_award(self, lab, dontPrompt=False):
         '''Sets the award for the connection for use in import_data
            if dontPrompt is False will ask the User to choose if there
            are more than one award for the connection.lab otherwise
            the first award for the lab will be used
         '''
         self.award = None
-        labjson = ff_utils.get_metadata(lab, key=self.key)
-        if labjson.get('awards') is not None:
-            awards = labjson.get('awards')
-            # if don't prompt is active take first lab
-            if dontPrompt:
-                self.award = awards[0]['@id']
-                return
-            # if there is one lab return it as lab
-            if len(awards) == 1:
-                self.award = awards[0]['@id']
-                return
-            # if there are multiple labs
-            achoices = []
-            print("Multiple awards for {labname}:".format(labname=lab))
-            for i, awd in enumerate(awards):
-                ch = str(i + 1)
-                achoices.append(ch)
-                print("  ({choice}) {awdname}".format(choice=ch, awdname=awd['@id']))
-            # re try the input until a valid choice is input
-            awd_resp = ''
-            while awd_resp not in achoices:
-                awd_resp = str(input("Select the award for this session {choices}: ".format(choices=achoices)))
-            self.award = awards[int(awd_resp) - 1]['@id']
-            return
+        if lab is not None:
+            labjson = ff_utils.get_metadata(lab, key=self.key)
+            if labjson.get('awards') is not None:
+                awards = labjson.get('awards')
+                if len(awards) == 1:
+                    self.award = awards[0]['@id']
+                    return
+
+                # if don't prompt is active leave None
+                if dontPrompt:
+                    return
+
+                # if there are multiple awards
+                achoices = []
+                print("Multiple awards for {labname}:".format(labname=lab))
+                for i, awd in enumerate(awards):
+                    ch = str(i + 1)
+                    achoices.append(ch)
+                    print("  ({choice}) {awdname}".format(choice=ch, awdname=awd['@id']))
+                # re try the input until a valid choice is input
+                awd_resp = ''
+                while awd_resp not in achoices:
+                    awd_resp = str(input("Select the award for this session {choices}: ".format(choices=achoices)))
+                self.award = awards[int(awd_resp) - 1]['@id']
+        return
 
     def prompt_for_lab_award(self):
         '''Check to see if user submits_for multiple labs or the lab
             has multiple awards and if so prompts for the one to set
             for the connection
         '''
-        if self.labs:
+        if self.labs is not None:
             if len(self.labs) > 1:
                 lchoices = []
                 print("Submitting for multiple labs:")
@@ -195,8 +196,9 @@ class FDN_Connection(object):
                     return
                 else:
                     self.lab = self.labs[int(lab_resp) - 1]
-
-        self.set_award(self.lab, False)
+            self.set_award(self.lab, False)
+        else:
+            self.set_award(None)
 
 
 @attr.s

--- a/wranglertools/get_field_info.py
+++ b/wranglertools/get_field_info.py
@@ -182,25 +182,26 @@ class FDN_Connection(object):
             has multiple awards and if so prompts for the one to set
             for the connection
         '''
-        if not lab and self.labs is not None:
-            if len(self.labs) > 1:
-                lchoices = []
-                print("Submitting for multiple labs:")
-                for i, lab in enumerate(self.labs):
-                    ch = str(i + 1)
-                    lchoices.append(ch)
-                    print("  ({choice}) {labname}".format(choice=ch, labname=lab))
-                lab_resp = str(input("Select the lab for this connection {choices}: ".format(choices=lchoices)))
-                if lab_resp not in lchoices:
-                    print("Not a valid choice - using {default}".format(default=self.lab))
-                    return
-                else:
-                    self.lab = self.labs[int(lab_resp) - 1]
+        if lab:
+            if not award:
+                self.set_award(self.lab)
+        else:
+            if self.labs is not None:
+                if len(self.labs) > 1:
+                    lchoices = []
+                    print("Submitting for multiple labs:")
+                    for i, lab in enumerate(self.labs):
+                        ch = str(i + 1)
+                        lchoices.append(ch)
+                        print("  ({choice}) {labname}".format(choice=ch, labname=lab))
+                    lab_resp = str(input("Select the lab for this connection {choices}: ".format(choices=lchoices)))
+                    if lab_resp not in lchoices:
+                        print("Not a valid choice - using {default}".format(default=self.lab))
+                        return
+                    else:
+                        self.lab = self.labs[int(lab_resp) - 1]
             if not award:
                 self.set_award(self.lab, False)
-        else:
-            if not award:
-                self.set_award(None)
 
 
 @attr.s

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -1402,7 +1402,7 @@ def cabin_cross_check(connection, patchall, update, infile, remote, lab, award):
         if len(connection.labs) > 1:  # lab may be provided as an option or is None
             try:
                 labjson = ff_utils.get_metadata(lab, key=connection.key, add_on='frame=raw')
-                labuuid = labjson['uuid']
+                labjson['uuid']
             except (KeyError, TypeError):
                 print("Submitting Lab NOT FOUND: {}".format(lab))
                 connection.lab = None

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -1436,7 +1436,7 @@ def cabin_cross_check(connection, patchall, update, infile, remote, lab=None, aw
         connection.award = None
     else:  # make sure award is linked to lab
         if lab_json is not None:
-            labawards = labjson.get('awards', [])
+            labawards = lab_json.get('awards', [])
             if award_json.get('@id') not in labawards:
                 print("Award {} not associated with lab {} - exiting!".format(submit_award, submit_lab))
                 sys.exit(1)

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -1403,7 +1403,8 @@ def cabin_cross_check(connection, patchall, update, infile, remote):
 
     print("Submitting User:  {}".format(connection.email))
     if connection.lab is None:
-        print("WARNING: Submitting Lab and Award Unspecified\nLab and Award info must be included for all items or submission will fail")
+        print("WARNING: Submitting Lab and Award Unspecified")
+        print("Lab and Award info must be included for all items or submission will fail")
     else:
         print("Submitting Lab:   {}".format(connection.lab))
         print("Submitting Award: {}".format(connection.award))

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -1388,10 +1388,25 @@ def cabin_cross_check(connection, patchall, update, infile, remote):
     # check for multi labs and awards and reset connection appropriately
     if not remote:
         connection.prompt_for_lab_award()
+    else:
+        # running remotely cases:
+        # one lab one award - use them
+        # one lab with multiple awards or multiple Labs
+        #   - set lab and award to None
+        if len(connection.labs) > 1:
+            connection.lab = None
+            connection.award = None
+        else:
+            connection.set_award(connection.lab, remote)
+            if connection.award is None:
+                connection.lab = None
 
     print("Submitting User:  {}".format(connection.email))
-    print("Submitting Lab:   {}".format(connection.lab))
-    print("Submitting Award: {}".format(connection.award))
+    if connection.lab is None:
+        print("WARNING: Submitting Lab and Award Unspecified\nLab and Award info must be included for all items or submission will fail")
+    else:
+        print("Submitting Lab:   {}".format(connection.lab))
+        print("Submitting Award: {}".format(connection.award))
 
     # if dry-run, message explaining the test, and skipping user input
     if not patchall and not update:

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -1402,8 +1402,8 @@ def cabin_cross_check(connection, patchall, update, infile, remote, lab, award):
         if len(connection.labs) > 1:  # lab may be provided as an option or is None
             try:
                 labjson = ff_utils.get_metadata(lab, key=connection.key, add_on='frame=raw')
-                labjson['uuid']
-            except (KeyError, TypeError):
+                assert 'uuid' in labjson
+            except (AssertionError, TypeError):
                 print("Submitting Lab NOT FOUND: {}".format(lab))
                 connection.lab = None
             else:


### PR DESCRIPTION
This branch now accepts --lab and --award options that can use any valid identifier for those items.  Works for both --remote and non-remote users. 

- If there is only a single award and lab for a submitter then no prompt - like current behavior
- Checks to make sure that if lab and award are provided then the award is associated with the lab.  
- if --remote - Will set values to None if appropriate and thereby depend on the lab and award info to exist in the submitted sheets.