### PR TITLE
Update install instructions for Windows + bug fix + expand home path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Change Log
 3.1.0
 =====
 
-`PR 160 <https://github.com/4dn-dcic/Submit4DN/pull/160>`_
+`PR 161 <https://github.com/4dn-dcic/Submit4DN/pull/161>`_
 
 * Added documentation regarding how to install Submit4DN on Windows machines in
   a virtual environment. There is a bug in ``awscli`` or in ``pyenv-win``, which

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,19 @@ Submit4DN
 Change Log
 ----------
 
+3.1.0
+=====
+
+`PR 160 <https://github.com/4dn-dcic/Submit4DN/pull/160>`_
+
+* Added documentation regarding how to install Submit4DN on Windows machines in
+  a virtual environment. There is a bug in ``awscli`` or in ``pyenv-win``, which
+  requires to adjust the installation instructions for this use case (see
+  troubleshooting in ``README.md`` for details).
+
+* Added support for ``~`` in paths for file and attachment upload.
+
+* Bug fix: a ``show`` command was giving intermittent errors.
 
 3.0.1
 =====

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ virtual environment.
 ```
 deactivate
 pip install awscli
-<venv_name>\scripts\activate  # replace virtual environment name
+VENV\scripts\activate  # replace VENV with your virtual environment name
 aws --version  # this is to test that awscli is now installed correctly
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This package is not supported on older Python versions and is supported and test
 
 It is recommended to install this package in a virtual environment to avoid dependency clashes.
 
-Problems have been reported on recent MacOS X versions having to do with the inablity to find `libmagic`,
+Problems have been reported on recent MacOS X and Windows versions having to do with the inablity to find `libmagic`,
 a C library to check file types that is used by the `python-magic` library.
 
 eg. `ImportError: failed to find libmagic.  Check your installation`

--- a/README.md
+++ b/README.md
@@ -65,19 +65,10 @@ virtual environment.
 ```
 deactivate
 pip install awscli
-venv\scripts\activate
+<venv_name>\scripts\activate  # replace virtual environment name
 aws --version  # this is to test that awscli is now installed correctly
 ```
 
-Alternatively, it works also to modify `aws.cmd`. Run:
-
-```
-notepad venv\scripts\aws.cmd
-```
-
-and change the for loop in the first couple of lines where it loops over
-`cmd bat exe` to have it loop over `exe bat cmd` instead, so that it finds
-`python.exe` before it finds `python.cmd`.
 
 ## Connecting to the Data Portal
 To be able to use the provided tools, you need to generate an AccessKey on the [data portal](https://data.4dnucleome.org/).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,33 @@ brew install libmagic
 brew link libmagic  (if the link is already created is going to fail, don't worry about that)
 ```
 
+Additionally, problems have been reported on Windows when installing Submit4DN
+inside a virtual environment, due to `aws` trying to use the global python instead
+of the python inside the virtual environment.
+
+The workaround, then, because it’s actually OK if `aws` doesn’t use the python
+inside the virtual environment, is to just install `awscli` in the global
+environment before entering the virtual environment. Or if you discover the
+problem after you’re in, then go outside, install `awscli`, and re-enter the
+virtual environment.
+
+```
+deactivate
+pip install awscli
+venv\scripts\activate
+aws --version  # this is to test that awscli is now installed correctly
+```
+
+Alternatively, it works also to modify `aws.cmd`. Run:
+
+```
+notepad venv\scripts\aws.cmd
+```
+
+and change the for loop in the first couple of lines where it loops over
+`cmd bat exe` to have it loop over `exe bat cmd` instead, so that it finds
+`python.exe` before it finds `python.cmd`.
+
 ## Connecting to the Data Portal
 To be able to use the provided tools, you need to generate an AccessKey on the [data portal](https://data.4dnucleome.org/).
 If you do not yet have access, please contact [4DN Data Wranglers](mailto:support@4dnucleome.org)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Submit4DN"
-version = "3.0.1"
+version = "3.1.0"
 description = "Utility package for submitting data to the 4DN Data Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -19,8 +19,8 @@ def test_attachment_ftp_to_nowhere():
 
 
 def convert_to_path_with_tilde(string_path):
-    '''Helper function that introduces ~ in a valid path,
-       somehow the inverse of pathlib.Path.expanduser()'''
+    """Somehow the inverse of pathlib.Path.expanduser(). Helper function used
+    to generate valid paths containing ~ """
     path = pp.Path(string_path)
     absolute_path = path.resolve()
     home = absolute_path.home()

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -18,9 +18,18 @@ def test_attachment_ftp_to_nowhere():
     assert "urlopen error" in str(e.value)
 
 
+def convert_to_path_with_tilde(string_path):
+    path = pp.Path(string_path)
+    absolute_path = path.resolve()
+    home = absolute_path.home()
+    string_path_with_tilde = str(absolute_path).replace(str(home), '~')
+    return string_path_with_tilde
+
+
 @pytest.mark.file_operation
 def test_md5():
-    md5_keypairs = imp.md5('./tests/data_files/keypairs.json')
+    path = convert_to_path_with_tilde('./tests/data_files/keypairs.json')
+    md5_keypairs = imp.md5(path)
     assert md5_keypairs == "19d43267b642fe1868e3c136a2ee06f2"
 
 
@@ -41,6 +50,15 @@ def test_attachment_pdf():
 
 
 @pytest.mark.file_operation
+def test_attachment_expanduser_path():
+    path = convert_to_path_with_tilde("./tests/data_files/test.pdf")
+    attach = imp.attachment(path)
+    assert attach['download'] == 'test.pdf'
+    assert attach['type'] == 'application/pdf'
+    assert attach['href'].startswith('data:application/pdf;base64')
+
+
+@pytest.mark.file_operation
 def test_attachment_image_wrong_extension():
     with pytest.raises(ValueError) as excinfo:
         imp.attachment("./tests/data_files/test_jpeg.tiff")
@@ -52,18 +70,6 @@ def test_attachment_wrong_path():
     with pytest.raises(Exception) as e:
         imp.attachment("./tests/data_files/dontexisit.txt")
     assert "ERROR : The 'attachment' field has INVALID FILE PATH or URL" in str(e.value)
-
-
-@pytest.mark.file_operation
-def test_attachment_expanduser_path():
-    valid_path = pp.Path("./tests/data_files/test.pdf")
-    absolute_path = valid_path.resolve()
-    home = absolute_path.home()
-    string_path_with_tilde = str(absolute_path).replace(str(home), '~')
-    attach = imp.attachment(string_path_with_tilde)
-    assert attach['download'] == 'test.pdf'
-    assert attach['type'] == 'application/pdf'
-    assert attach['href'].startswith('data:application/pdf;base64')
 
 
 @pytest.mark.webtest

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -19,6 +19,8 @@ def test_attachment_ftp_to_nowhere():
 
 
 def convert_to_path_with_tilde(string_path):
+    '''Helper function that introduces ~ in a valid path,
+       somehow the inverse of pathlib.Path.expanduser()'''
     path = pp.Path(string_path)
     absolute_path = path.resolve()
     home = absolute_path.home()

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -54,6 +54,18 @@ def test_attachment_wrong_path():
     assert "ERROR : The 'attachment' field has INVALID FILE PATH or URL" in str(e.value)
 
 
+@pytest.mark.file_operation
+def test_attachment_expanduser_path():
+    valid_path = pp.Path("./tests/data_files/test.pdf")
+    absolute_path = valid_path.resolve()
+    home = absolute_path.home()
+    string_path_with_tilde = str(absolute_path).replace(str(home), '~')
+    attach = imp.attachment(string_path_with_tilde)
+    assert attach['download'] == 'test.pdf'
+    assert attach['type'] == 'application/pdf'
+    assert attach['href'].startswith('data:application/pdf;base64')
+
+
 @pytest.mark.webtest
 def test_attachment_url():
     attach = imp.attachment("http://example.com/index.html")

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -139,7 +139,8 @@ list_of_loadxl_fields = [
 ]
 
 
-def md5(path):
+def md5(path_string):
+    path = pp.path(path_string)
     md5sum = hashlib.md5()
     with open(path, 'rb') as f:
         for chunk in iter(lambda: f.read(1024*1024), b''):
@@ -1451,8 +1452,9 @@ def upload_file(creds, path):  # pragma: no cover
     # ~12-15s/GB from AWS Ireland - AWS Oregon
     print("Uploading file.")
     start = time.time()
+    path_object = pp.Path(path)
     try:
-        source = path
+        source = path_object
         target = creds['upload_url']
         print("Going to upload {} to {}.".format(source, target))
         command = ['aws', 's3', 'cp']

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -140,7 +140,7 @@ list_of_loadxl_fields = [
 
 
 def md5(path_string):
-    path = pp.path(path_string)
+    path = pp.Path(path_string)
     md5sum = hashlib.md5()
     with open(path, 'rb') as f:
         for chunk in iter(lambda: f.read(1024*1024), b''):

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -176,8 +176,8 @@ def attachment(path):
         'image/tiff',
     )
     ftp_attach = False
-    path = pp.Path(path).expanduser()
-    if not path.is_file():
+    path = str(pp.Path(path).expanduser())
+    if not pp.Path(path).is_file():
         # if the path does not exist, check if it works as a URL
         if path.startswith("ftp://"):  # grab the file from ftp
             print("\nINFO: Attempting to download file from this url %s" % path)
@@ -210,10 +210,10 @@ def attachment(path):
                 raise Exception("\nERROR : Cannot write a tmp file to disk - {}".format(e))
 
     attach = {}
-    filename = path.name
+    filename = pp.PurePath(path).name
     guessed_mime = mimetypes.guess_type(path)[0]
     detected_mime = magic.from_file(path, mime=True)
-    # NOTE: this whole guesssing and detecting bit falls apart for zip files which seems a bit dodgy
+    # NOTE: this whole guessing and detecting bit falls apart for zip files which seems a bit dodgy
     # some .zip files are detected as generic application/octet-stream but don't see a good way to verify
     # basically relying on extension with a little verification by magic for most file types
     if guessed_mime not in ALLOWED_MIMES:

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -176,7 +176,8 @@ def attachment(path):
         'image/tiff',
     )
     ftp_attach = False
-    path = str(pp.Path(path).expanduser())
+    if path.startswith('~'):
+        path = str(pp.Path(path).expanduser())
     if not pp.Path(path).is_file():
         # if the path does not exist, check if it works as a URL
         if path.startswith("ftp://"):  # grab the file from ftp

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -1468,7 +1468,7 @@ def upload_file(creds, path):  # pragma: no cover
     else:
         end = time.time()
         duration = end - start
-        show("Uploaded in %.2f seconds" % duration)
+        print("Uploaded in %.2f seconds" % duration)
 
 
 def running_on_windows_native():

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -176,7 +176,8 @@ def attachment(path):
         'image/tiff',
     )
     ftp_attach = False
-    if not pp.Path(path).is_file():
+    path = pp.Path(path).expanduser()
+    if not path.is_file():
         # if the path does not exist, check if it works as a URL
         if path.startswith("ftp://"):  # grab the file from ftp
             print("\nINFO: Attempting to download file from this url %s" % path)
@@ -209,7 +210,7 @@ def attachment(path):
                 raise Exception("\nERROR : Cannot write a tmp file to disk - {}".format(e))
 
     attach = {}
-    filename = pp.PurePath(path).name
+    filename = path.name
     guessed_mime = mimetypes.guess_type(path)[0]
     detected_mime = magic.from_file(path, mime=True)
     # NOTE: this whole guesssing and detecting bit falls apart for zip files which seems a bit dodgy

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -1527,7 +1527,7 @@ def _verify_and_return_item(item, connection):
 def cabin_cross_check(connection, patchall, update, infile, remote, lab=None, award=None):
     """Set of check for connection, file, dryrun, and prompt."""
     print("Running on:       {server}".format(server=connection.key['server']))
-    # check input file (xls)
+    # check input file (xlsx)
     if not pp.Path(infile).is_file():
         print(f"File {infile} not found!")
         sys.exit(1)

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -140,7 +140,7 @@ list_of_loadxl_fields = [
 
 
 def md5(path_string):
-    path = pp.Path(path_string)
+    path = pp.Path(path_string).expanduser()
     md5sum = hashlib.md5()
     with open(path, 'rb') as f:
         for chunk in iter(lambda: f.read(1024*1024), b''):
@@ -1452,7 +1452,7 @@ def upload_file(creds, path):  # pragma: no cover
     # ~12-15s/GB from AWS Ireland - AWS Oregon
     print("Uploading file.")
     start = time.time()
-    path_object = pp.Path(path)
+    path_object = pp.Path(path).expanduser()
     try:
         source = path_object
         target = creds['upload_url']


### PR DESCRIPTION
Various independent updates:

1. Update installation instructions for Windows inside a virtual environment, as the standard protocol of `pip install submit4dn` caused `awscli` being unable to find python in this context. Internal documentation in this JIRA ticket [C4-931](https://hms-dbmi.atlassian.net/browse/C4-931).
2. Bug fix: `show` command introduced in #160 was copied from SubmitCGAP but the [corresponding function definition](https://github.com/dbmi-bgm/SubmitCGAP/blob/master/submit_cgap/utils.py#L8-L20) was not imported. This was giving intermittent errors (not sure why sometimes it worked). It seems fine to use `print` instead.
3. Added `expanduser` to paths for files and attachments, so that a path can be written in the `xlsx` file also as `~/Documents/file.fastq`. Tested on both Mac OS and Windows.