### PR TITLE
Tolerate cells with None value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Custom_scripts/
 Data_Files/MicroscopyCalibration/Files/
 .pytest_cache/
 .python-version
+
+# PyCharm metadata
+.idea/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Submit4DN
 Change Log
 ----------
 
+3.1.1
+=====
+
+* Bug fix: some "empty" cells were not handled correctly.
+
 3.1.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Submit4DN"
-version = "3.1.0"
+version = "3.1.1"
 description = "Utility package for submitting data to the 4DN Data Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -286,7 +286,7 @@ def cell_value(cell):
     if ctype == openpyxl.cell.cell.TYPE_ERROR:  # pragma: no cover
         raise ValueError('Cell %s contains a cell error' % str(cell.coordinate))
     elif value is None:
-        return ''
+        return None
     elif ctype == openpyxl.cell.cell.TYPE_BOOL:
         boolstr = str(value).strip()
         if boolstr == 'TRUE':

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -285,6 +285,8 @@ def cell_value(cell):
     value = cell.value
     if ctype == openpyxl.cell.cell.TYPE_ERROR:  # pragma: no cover
         raise ValueError('Cell %s contains a cell error' % str(cell.coordinate))
+    elif value is None:
+        return ''
     elif ctype == openpyxl.cell.cell.TYPE_BOOL:
         boolstr = str(value).strip()
         if boolstr == 'TRUE':

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -286,7 +286,7 @@ def cell_value(cell):
     if ctype == openpyxl.cell.cell.TYPE_ERROR:  # pragma: no cover
         raise ValueError('Cell %s contains a cell error' % str(cell.coordinate))
     elif value is None:
-        return None
+        return ''
     elif ctype == openpyxl.cell.cell.TYPE_BOOL:
         boolstr = str(value).strip()
         if boolstr == 'TRUE':


### PR DESCRIPTION
Cells with `None` value seem to be recognized as `TYPE_STRING` or `TYPE_INLINE`, but then the `.strip()` method would fail because it is not a string. I am not sure why this happens.

We had issues where an xlsx file from unknown source looked fine when opened in Excel, but was giving troubles when ingested with Submit4DN. The only way to ensure Submit4DN could read it was to generate a "clean" new xlsx file with the same tool. Hopefully (not tested), this fix should resolve/alleviate these issues.

It seems fine to return an empty string `''` when `None` value is present, as this is evaluated by `row_generator` function which checks whether the row is entirely empty. Having empty strings as cell values in this case is recognized as an empty row, as it should be.