### PR TITLE
allow extra_file upload.  

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ Submit4DN
 Change Log
 ----------
 
+3.4.1
+=====
+
+`PR 170: fix bug in extra file upld <https://github.com/4dn-dcic/Submit4DN/pull/170>`_
+
+* Update to allow extra_files to be uploaded even if the regular file was already uploaded (which was previously stymied by permission denied for POST to get extracreds)
+
 3.4.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Submit4DN"
-version = "3.4.0"
+version = "3.4.1"
 description = "Utility package for submitting data to the 4DN Data Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -1571,7 +1571,10 @@ def pf_w_extfiles_resp():
 
 def test_update_item_extrafiles(mocker, connection_mock, pf_w_extfiles_resp):
     extrafiles = {'pairs_px2': '/test/file/test_pairs.gz.px2', 'pairsam_px2': '/test/file/testfile.pairs.sam.gz'}
+    upld_creds = [{'file_format': 'pairs_px2', 'upload_credentials': 'px2creds'},
+                  {'file_format': 'pairsam_px2', 'upload_credentials': 'px2creds'}]
     mocker.patch('wranglertools.import_data.ff_utils.post_metadata', return_value=pf_w_extfiles_resp)
+    mocker.patch('wranglertools.import_data.get_upload_creds', return_value=upld_creds)
     mocker.patch('wranglertools.import_data.upload_extra_file', side_effect=[None, None])
     mocker.patch('wranglertools.import_data.ff_utils.get_metadata', side_effect=[
         {'uuid': 'd13d06cf-218e-4f61-aaf0-91f226348b2c'}, {'uuid': 'd13d06cf-218e-6f61-aaf0-91f226248b2c'}

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -896,6 +896,7 @@ def update_item(verb, file_to_upload, post_json, filename_to_post, extrafiles, c
     if extrafiles:
         extcreds = e['@graph'][0].get('extra_file_creds')
         if not extcreds:
+            time.sleep(5)
             extcreds = get_upload_creds(e['@graph'][0]['accession'], connection, extfilecreds=True)
         for fformat, filepath in extrafiles.items():
             try:


### PR DESCRIPTION
@willronchetti I'd like your take on this.  I ran into what I think is something of a corner case but inconsistent behavior has me second guessing myself.

The situation is that a user uploaded some analysis results as processed files - they included bams and pairs files.  
By default QCs are not run on User provided files but for some types they could be so I updated foursight checks for BamQC and PairsQC to allow a parameter to run these QC on non_dcic files.  Turns out that the QCs were triggered but errored.  Not sure on the BamQC but the PairsQC appears to require it's pairs_px2 extra file to run.  The lab offered to provide their index files and I wanted to make sure that I could have them upload them using Submit4DN.  I was testing out spreadsheets and hitting an exception because if a file has already been uploaded and you are just patching it with extra_files the extra_file_creds are not immediately available so I added some code to get them if they weren't already there.  

I thought I had got it working but then I noticed that it seemed to work intermittently.  Upon reflection I think what may be happening is that an initial patch without an upload is required and then the second go round the upload works?  But I am not sure why that is the case.  Or maybe it's a timing thing?  Any thought would be helpful.