### PR TITLE
validation error report update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ Submit4DN
 Change Log
 ----------
 
+4.0.3
+=====
+
+`PR 176: bug fix on error reporting <https://github.com/4dn-dcic/Submit4DN/pull/176>`_
+
+* fix of bug introduced by the previous error reporting fix
+* test to cover that case
+
 4.0.2
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Submit4DN"
-version = "4.0.2"
+version = "4.0.3"
 description = "Utility package for submitting data to the 4DN Data Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -280,16 +280,21 @@ def test_combine_set_expsets_with_existing():
 
 
 def test_error_report(connection_mock):
-    # There are 6 errors in the err_dict, 5 of them are legit, 1 is checked against the all aliases list, and excluded
+    # There are 7 errors in the err_dict, 5 of them are legit, 2 are checked against the all aliases list, and excluded
     err_dict = {
                     "title": "Unprocessable Entity",
                     "status": "error",
                     "errors": [
                         {"location": "body",
                          "description": "Test for error with no name"},
-                        {# This one should be excluded from report as this alias is in the sheet alias list
+                        {
+                         # This one should be excluded from report as this alias is in the sheet alias list
                          "name": "Schema: ", "location": "body",
                          "description": "Unable to resolve link: siyuan-wang-lab:region_1MB_TAD_1"},
+                        {
+                         # This also excluded - error format different (includes type name)
+                         "name": "Schema: ", "location": "body",
+                         "description": "Unable to resolve link: /GenomicRegion/siyuan-wang-lab:region_1MB_TAD_1"},
                         {"name": "Schema: ", "location": "body",
                          "description": "Unable to resolve link: siyuan-wang-lab:region_5MB_TAD_2"},
                         {"location": "body", "name": "Schema: genome_location.1",

--- a/wranglertools/import_data.py
+++ b/wranglertools/import_data.py
@@ -798,6 +798,7 @@ def error_report(error_dic, sheet, all_aliases, connection, error_id=''):
                 elif error_description.endswith(nf_txt):
                     alias_bit = error_description.replace(nf_txt, '').replace("'", '')
                 if alias_bit:
+                    alias_bit = alias_bit.split('/')[-1]
                     not_found = alias_bit.strip()
                 # ignore ones about existing aliases
                 if not_found and not_found in all_aliases:


### PR DESCRIPTION
Seeing reporting of 'Unable to resolve link' errors for items that are included in the workbook that should be ignored as errors on dry run as they will be posted before the item that is linking to it when actually posting.

I inadvertently introduced this for cases where the alias was provided as the 'error_id' parameter to the error_report function when attempting to fix the bug that prevented reporting of other types of validation errors in an informative way.

The issue was due to the error responses including the item type concatenated with the alias string, and now because of removal of the clause to use the alias if provided as a parameter in order to make the error reporting more informative there needs to be additional parsing to get the alias bit and just that with no extra text.
`{'location': 'body', 'name': 'Schema: ', 'description': 'Unable to resolve link: /Biosample/test-old-dekker-lab:Biosample_hap1cellsT2_HAP1-XH-G1-SD20221126-ED20221203'}`
Is an example of the returned response and the change here will remove the /Biosample/ part so only the alias remains to compare with other aliases in the workbook.